### PR TITLE
timezone in title respects time_format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ShadowFinder"
-version = "0.2.0"
+version = "0.2.1"
 description = "Find possible locations of shadows."
 authors = ["Bellingcat"]
 license = "MIT License"

--- a/shadowfinder/shadowfinder.py
+++ b/shadowfinder/shadowfinder.py
@@ -49,7 +49,7 @@ class ShadowFinder:
         self.find_shadows()
         fig = self.plot_shadows()
         fig.savefig(
-            f"shadow_finder_{self.date_time.strftime('%Y%m%d-%H%M%S-%Z')}_{self.object_height}_{self.shadow_length}.png"
+            f"shadow_finder_{self.date_time.strftime('%Y%m%d-%H%M%S')}-{self.time_format.title()}_{self.object_height}_{self.shadow_length}.png"
         )
 
     def generate_timezone_grid(self):
@@ -181,7 +181,7 @@ class ShadowFinder:
 
         # plt.colorbar(label='Relative Shadow Length Difference')
         plt.title(
-            f"Possible Locations at {self.date_time.strftime('%Y-%m-%d %H:%M:%S %Z')}\n(object height: {self.object_height}, shadow length: {self.shadow_length})"
+            f"Possible Locations at {self.date_time.strftime('%Y-%m-%d %H:%M:%S')} {self.time_format.title()}\n(object height: {self.object_height}, shadow length: {self.shadow_length})"
         )
         self.fig = fig
         return fig


### PR DESCRIPTION
#9 Previously the timezone in the title always showed UTC.

Now it displays either Utc or Local depending on what time_format is set to.

This is also replicated to the filename.

shadow_finder_20241103-112500-Utc_10_8.png
<img width="584" alt="image" src="https://github.com/bellingcat/ShadowFinder/assets/57358338/26191f1e-f55f-4c86-901b-8e39505d399e">

shadow_finder_20241103-113000-Local_10_8.png
<img width="584" alt="image" src="https://github.com/bellingcat/ShadowFinder/assets/57358338/be4027db-60c5-426c-adc5-4f33a919d01c">
