### PR TITLE
Add timezone grid caching to CLI (#17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ShadowFinder"
-version = "0.4.0"
+version = "0.5.0"
 description = "Find possible locations of shadows."
 authors = ["Bellingcat"]
 license = "MIT License"

--- a/src/shadowfinder/cli.py
+++ b/src/shadowfinder/cli.py
@@ -68,6 +68,7 @@ class ShadowFinderCli:
         date: str,
         time: str,
         time_format: str = "utc",
+        grid: str = "timezene_grid.json",
     ) -> None:
         """
         Locate a shadow based on the solar altitude angle and the date and time.
@@ -87,7 +88,7 @@ class ShadowFinderCli:
             time_format=time_format,
             sun_altitude_angle=sun_altitude_angle,
         )
-        shadow_finder.quick_find()
+        shadow_finder.quick_find(grid)
 
     @staticmethod
     def generate_timezone_grid(

--- a/src/shadowfinder/cli.py
+++ b/src/shadowfinder/cli.py
@@ -41,6 +41,7 @@ class ShadowFinderCli:
         date: str,
         time: str,
         time_format: str = "utc",
+        grid: str = "timezone_grid.json",
     ) -> None:
         """
         Find the shadow length of an object given its height and the date and time.
@@ -59,7 +60,7 @@ class ShadowFinderCli:
         shadow_finder = ShadowFinder(
             object_height, shadow_length, date_time, time_format
         )
-        shadow_finder.quick_find()
+        shadow_finder.quick_find(grid)
 
     @staticmethod
     def find_sun(
@@ -87,3 +88,16 @@ class ShadowFinderCli:
             sun_altitude_angle=sun_altitude_angle,
         )
         shadow_finder.quick_find()
+
+    @staticmethod
+    def generate_timezone_grid(
+        grid: str = "timezone_grid.json",
+    ) -> None:
+        """
+        Generate a timezone grid file.
+        :param grid: File path to save the timezone grid.
+        """
+
+        shadow_finder = ShadowFinder()
+        shadow_finder.generate_timezone_grid()
+        shadow_finder.save_timezone_grid(grid)

--- a/src/shadowfinder/shadowfinder.py
+++ b/src/shadowfinder/shadowfinder.py
@@ -93,8 +93,13 @@ class ShadowFinder:
             # Lengths and angle are None and we use the same values as before
             pass
 
-    def quick_find(self):
-        self.generate_timezone_grid()
+    def quick_find(self, timezone_grid="timezone_grid.json"):
+        # try to load timezone grid from file, generate if not found
+        try:
+            self.load_timezone_grid(timezone_grid)
+        except FileNotFoundError:
+            self.generate_timezone_grid()
+
         self.find_shadows()
         fig = self.plot_shadows()
 

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -24,6 +24,9 @@ COMMANDS
 
      find_sun
        Locate a shadow based on the solar altitude angle and the date and time.
+
+     generate_timezone_grid
+       Generate a timezone grid file.
 """
 
     # WHEN


### PR DESCRIPTION
I've gone ahead and implemented the changes described in [Galen's comment](https://github.com/bellingcat/ShadowFinder/issues/17#issuecomment-2242439921). The only notable change in behaviour is that now, by default, `find_sun` and `find` will attempt to read from `timezone_grid.json` (even if no `--grid` argument is passed). If this is unwanted, I can change it back, I just thought it would be a good default.

While testing, I found that `finder.generate_timezone_grid()` generates a JSON file that doesn't match the `timezone_grid.json` currently in this repo... is that intentional? Also, `shadowfinder generate_timezone_grid` will overwrite the file it's given — should that be changed?